### PR TITLE
Make timezone on sidebar not a link

### DIFF
--- a/_includes/contact.html
+++ b/_includes/contact.html
@@ -33,7 +33,7 @@
 
     {% if sidebar.timezone %}
     <li class="timezone">
-      <a href="">{{ sidebar.timezone }}</a>
+      {{ sidebar.timezone }}
     </li>
     {% endif %}
 


### PR DESCRIPTION
Remove <a> tag: https://www.w3schools.com/tags/tag_a.asp

Currently timezone (which using as location) appears as a link on the sidebar. The link redirects to the page...so lets remove the link